### PR TITLE
Fix README.md formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ or
 Search for all bullish or bearish using
 
 
-````
+```js
 var twoDayBullishInput = {
   open: [23.25,15.36],
   high: [25.10,30.87],


### PR DESCRIPTION
Removed extra back tick and added language to the code block for the bullish indicator example. This also fixes the formatting for the remaining readme