### PR TITLE
Fix the import path of StockData.d.ts in /oscillators/CCI.d.ts

### DIFF
--- a/declarations/oscillators/CCI.d.ts
+++ b/declarations/oscillators/CCI.d.ts
@@ -1,4 +1,4 @@
-import { CandleData } from '../../src/StockData';
+import { CandleData } from '../StockData';
 import { Indicator, IndicatorInput } from '../indicator/indicator';
 export declare class CCIInput extends IndicatorInput {
     high: number[];


### PR DESCRIPTION
Fix this issue: https://github.com/anandanand84/technicalindicators/issues/93
```ts
node_modules/technicalindicators/declarations/oscillators/CCI.d.ts(1,28): error TS2307: Cannot find module '../../src/StockData'.
```