### PR TITLE
Fixed EMA returning 'undefined' when input = 0

### DIFF
--- a/src/moving_averages/EMA.ts
+++ b/src/moving_averages/EMA.ts
@@ -22,7 +22,7 @@ export class EMA extends Indicator{
             var tick  = yield;
             var prevEma;
             while (true) {
-                if(prevEma && tick){
+                if(prevEma !== undefined && tick !== undefined){
                     prevEma = ((tick - prevEma) * exponent) + prevEma;
                     tick = yield prevEma;
                 }else {

--- a/src/moving_averages/WEMA.ts
+++ b/src/moving_averages/WEMA.ts
@@ -22,13 +22,13 @@ export class WEMA extends Indicator{
             var tick  = yield;
             var prevEma;
             while (true) {
-                if(prevEma && tick != undefined){
+                if(prevEma !== undefined && tick != undefined){
                     prevEma = ((tick - prevEma) * exponent) + prevEma;
                     tick = yield prevEma;
                 }else {
                     tick = yield;
                     prevEma = sma.nextValue(tick)
-                    if(prevEma)
+                    if(prevEma !== undefined)
                         tick = yield prevEma;
                 }
             }

--- a/src/moving_averages/WEMA.ts
+++ b/src/moving_averages/WEMA.ts
@@ -22,7 +22,7 @@ export class WEMA extends Indicator{
             var tick  = yield;
             var prevEma;
             while (true) {
-                if(prevEma !== undefined && tick != undefined){
+                if(prevEma !== undefined && tick !== undefined){
                     prevEma = ((tick - prevEma) * exponent) + prevEma;
                     tick = yield prevEma;
                 }else {


### PR DESCRIPTION
EMA/WEMA had returned `undefined` when input was `0`, for example when input was not simply price, but price difference from bar to bar.