### PR TITLE
Replace compromised external link with archived version

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ SMA.calculate({period : 5, values : [1,2,3,4,5,6,7,8,9]});
 
 # Crypto Trading hub
 
-If you like this project. You'll love my other project [crypto trading hub](https://cryptotrading-hub.com/?utm_source=github&utm_medium=readme&utm_campaign=technicalindicators "Crypto trading hub")
+If you like this project. You'll love my other project [crypto trading hub](https://web.archive.org/web/20220331055415/https://cryptotrading-hub.com/)
 
 1. Its free
 1. Realtime price charts 


### PR DESCRIPTION
It appears that [https://cryptotrading-hub.com/](https://cryptotrading-hub.com/) has been taken over by spammers and now redirects to ad tracking links, so I recommend replacing it with an archived version instead.
