### PR TITLE
Fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # TechnicalIndicators
 
-A javascript technical indicators written in typescript.
+JavaScript technical indicators written in TypeScript.
 
 
 # Installation


### PR DESCRIPTION
Fixes grammatical error in README where 'A javascript technical indicators written in typescript' should be 'JavaScript technical indicators written in TypeScript'